### PR TITLE
Update HypriotOS for ARM device matrix

### DIFF
--- a/support-matrix.md
+++ b/support-matrix.md
@@ -7,7 +7,7 @@ This is an (incomplete) list of ARM devices that have been tested or are in the 
 | Rock64 | [Xenial minimal rock64 0.5.15/4.4](https://github.com/ayufan-rock64/linux-build/releases/tag/0.5.15)  | docker-ce=18.04.0~ce~3-0~ubuntu | 1.9.7, 1.10.5, 1.11.0 | 1.9.7, 1.10.5, 1.11.0 |
 | RPi 3B/3B+ | [Raspbian Stretch Lite/4.14](https://www.raspberrypi.org/downloads/raspbian/) | docker-ce=18.04.0~ce~3-0~raspbian | 1.9.7, 1.10.5 | 1.9.7, 1.10.5 |
 | Cavium ThunderX (Packet c1.large.arm) | Debian 9 | | | |
-| RPi 3B/3B+ | [Hypriot OS/4.14.34](http://blog.hypriot.com/downloads/)  | docker-ce=18.04.0 | untested | untestd |
+| RPi 3B/3B+ | [Hypriot OS/4.14.34](http://blog.hypriot.com/downloads/)  | docker-ce=18.04.0 | 1.9.6 | 1.9.6 |
 
 ## Kubernetes software matrix
 


### PR DESCRIPTION
Some informations : 

Kubernetes cluster : 

```
jarvis@jarvis-master:~$ kubectl get nodes -o wide
NAME            STATUS    ROLES     AGE       VERSION   EXTERNAL-IP   OS-IMAGE                       KERNEL-VERSION               CONTAINER-RUNTIME
jarvis-master   Ready     master    75d       v1.9.6    <none>        Ubuntu 16.04.3 LTS             4.4.77-rockchip-ayufan-136   docker://18.3.1
jarvis-node1    Ready     <none>    75d       v1.9.6    <none>        Debian GNU/Linux 9 (stretch)   4.14.37-hypriotos-v8         docker://18.4.0
jarvis-node2    Ready     <none>    75d       v1.9.6    <none>        Debian GNU/Linux 9 (stretch)   4.14.37-hypriotos-v8         docker://18.4.0
jarvis-node3    Ready     <none>    75d       v1.9.6    <none>        Debian GNU/Linux 9 (stretch)   4.14.37-hypriotos-v8         docker://18.4.0
```

Master:

```
jarvis@jarvis-master:~$ uname -a
Linux jarvis-master 4.4.77-rockchip-ayufan-136 #1 SMP Thu Oct 12 09:14:48 UTC 2017 aarch64 aarch64 aarch64 GNU/Linux
jarvis@jarvis-master:~$ dpkg -l|grep kube
ii  kubeadm                                  1.9.6-00                                   arm64        Kubernetes Cluster Bootstrapping Tool
ii  kubectl                                  1.9.6-00                                   arm64        Kubernetes Command Line Tool
ii  kubelet                                  1.9.6-00                                   arm64        Kubernetes Node Agent
ii  kubernetes-cni                           0.6.0-00                                   arm64        Kubernetes CNI
```

Workers:

```
HypriotOS/arm64: pirate@jarvis-node3 in ~
$ uname -a
Linux jarvis-node3 4.14.37-hypriotos-v8 #1 SMP PREEMPT Sun Apr 29 17:26:16 UTC 2018 aarch64 GNU/Linux
HypriotOS/arm64: pirate@jarvis-node3 in ~
$ dpkg -l|grep kube
ii  kubeadm                       1.9.6-00                       arm64        Kubernetes Cluster Bootstrapping Tool
ii  kubectl                       1.9.6-00                       arm64        Kubernetes Command Line Tool
ii  kubelet                       1.9.6-00                       arm64        Kubernetes Node Agent
ii  kubernetes-cni                0.6.0-00                       arm64        Kubernetes CNI
```